### PR TITLE
修改nginx配置

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,8 @@ services:
       - elasticsearch1
     networks:
         - code-network 
-    ports:
-      - 3000:3000
+    #ports:
+    #  - 3000:3000
       
 volumes:
   esdata12:

--- a/services/web/nginx/conf/conf.d/default.conf
+++ b/services/web/nginx/conf/conf.d/default.conf
@@ -17,6 +17,10 @@ server {
     }
 }
 
+upstream  golang {
+    server golang:3000;
+}
+
 server {
     listen 80;
     server_name tracejs1.fecshop.com;
@@ -27,7 +31,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://207.148.8.72:3000;      # 这里ip地址设置成你的宿主主机ip+端口（或许可以localhost:端口，我没试）
+        proxy_pass http://golang/;      # 这里ip地址设置成你的宿主主机ip+端口（或许可以localhost:端口，我没试）
 		# proxy_buffer_size 64k;
         # proxy_buffers 32 32k;
         # proxy_busy_buffers_size 128k;


### PR DESCRIPTION
修改nginx.conf配置，让nginx直接通过容器bridge网络，内部代理golang，这样不用将golang的3000端口映射到宿主机，提高安全性，配置golang的 ./services/golang/etc/fec-go/config.ini也会简单方便